### PR TITLE
feat/show possible collisions

### DIFF
--- a/src/collect-pick-info.ts
+++ b/src/collect-pick-info.ts
@@ -14,11 +14,11 @@
 
 import { parseCommitLinks, parsePullRequestLinks } from "./parsing";
 import {
-  queryCommitInfo,
-  queryProjectID,
-  queryProjectInbox,
-  queryPullRequest,
-  queryCommitFilesChanged,
+    queryCommitFilesChanged,
+    queryCommitInfo,
+    queryProjectID,
+    queryProjectInbox,
+    queryPullRequest,
 } from "./queries";
 
 // accept sort argument from bun argv, either "asc" or "desc" from --sort=asc
@@ -42,17 +42,17 @@ const fmtBold = "\x1b[1m";
 const maxWidth = process.stdout.columns;
 
 function formatFileCollisions(files: string[]): string {
-  const prefix = ' - ';
-  const output: string[] = []; 
+  const prefix = " - ";
+  const output: string[] = [];
   const limit = prefix.length + 4;
   for (const file of files) {
     let label = file;
-    if ((file.length + prefix.length) > maxWidth) {
-      label = '...' + file.substr(file.length + prefix.length + 3 - maxWidth);
+    if (file.length + prefix.length > maxWidth) {
+      label = "..." + file.substr(file.length + prefix.length + 3 - maxWidth);
     }
     output.push(`${prefix}${fmtRed}${fmtBold}${label}${fmtReset}`);
   }
-  return output.join('\n');
+  return output.join("\n");
 }
 
 // accept argument from bun argv
@@ -66,7 +66,7 @@ if (!targetRelease) {
   const releaseRegex = /^0\.\d+\.\d+-rc\d+$/;
   if (!releaseRegex.test(targetRelease)) {
     console.error(
-      "Please provide a targetRelease in the format of '0.76.0-rc3'"
+      "Please provide a targetRelease in the format of '0.76.0-rc3'",
     );
     process.exit(1);
   } else {
@@ -102,7 +102,9 @@ for (const issue of inboxIssues) {
     for (const pullRequest of pullRequestLinks) {
       // get the pull request number on the end
       const prData = await queryPullRequest(
-        Number.parseInt(pullRequest.substring(pullRequest.lastIndexOf("/") + 1))
+        Number.parseInt(
+          pullRequest.substring(pullRequest.lastIndexOf("/") + 1),
+        ),
       );
 
       if (prData) {
@@ -137,7 +139,7 @@ for (const issue of inboxIssues) {
   }
 
   // Check for files where collisions are likely
-  for (const {files} of output) {
+  for (const { files } of output) {
     for (const file of files) {
       const count = allFiles.get(file) ?? 0;
       allFiles.set(file, count + 1);
@@ -160,7 +162,9 @@ const sortedPicks = allPickItems.sort((a, b) => {
 
 for (const pick of sortedPicks) {
   console.log(formatResultLine(pick.commitHash, pick.createdAt, pick.title));
-  const collisions = Array.from(pick.files).filter(file => (allFiles.get(file) ?? 0) > 1);
+  const collisions = Array.from(pick.files).filter(
+    (file) => (allFiles.get(file) ?? 0) > 1,
+  );
   console.log(formatFileCollisions(collisions));
 }
 

--- a/src/collect-pick-info.ts
+++ b/src/collect-pick-info.ts
@@ -18,6 +18,7 @@ import {
   queryProjectID,
   queryProjectInbox,
   queryPullRequest,
+  queryCommitFilesChanged,
 } from "./queries";
 
 // accept sort argument from bun argv, either "asc" or "desc" from --sort=asc
@@ -32,6 +33,26 @@ const verboseArg =
 function formatResultLine(commitHash: string, date: string, title: string) {
   const line = `${commitHash.substring(0, 7)} : ${date}`;
   return verboseArg ? `${line} : ${title}` : line;
+}
+
+const fmtRed = "\x1b[31m";
+const fmtReset = "\x1b[0m";
+const fmtBold = "\x1b[1m";
+
+const maxWidth = process.stdout.columns;
+
+function formatFileCollisions(files: string[]): string {
+  const prefix = ' - ';
+  const output: string[] = []; 
+  const limit = prefix.length + 4;
+  for (const file of files) {
+    let label = file;
+    if ((file.length + prefix.length) > maxWidth) {
+      label = '...' + file.substr(file.length + prefix.length + 3 - maxWidth);
+    }
+    output.push(`${prefix}${fmtRed}${fmtBold}${label}${fmtReset}`);
+  }
+  return output.join('\n');
 }
 
 // accept argument from bun argv
@@ -54,7 +75,6 @@ if (!targetRelease) {
 }
 
 const itemsToDiscuss: string[] = [];
-let pickCount = 0;
 
 const projectID = await queryProjectID(targetRelease);
 const inboxIssues = await queryProjectInbox({ projectID, targetRelease });
@@ -63,9 +83,11 @@ interface PickInfo {
   commitHash: string;
   createdAt: string;
   title: string;
+  files: Set<string>;
 }
 
 const allPickItems: PickInfo[] = [];
+const allFiles: Map<string, number> = new Map();
 
 // foreach issue in inboxIssues, call query issue
 for (const issue of inboxIssues) {
@@ -84,7 +106,9 @@ for (const issue of inboxIssues) {
       );
 
       if (prData) {
-        output.push({ commitHash: prData.commitHash, createdAt, title });
+        const commitHash: string = prData.commitHash;
+        const files = queryCommitFilesChanged(commitHash);
+        output.push({ commitHash, createdAt, title, files });
       } else {
         flagged = true;
         // TODO
@@ -101,12 +125,22 @@ for (const issue of inboxIssues) {
       const commitHash = commit.substring(commit.lastIndexOf("/") + 1);
       const commitInfo = await queryCommitInfo(commitHash);
       const parseCommitMessage = commitInfo.message.split("\n");
+      const files = queryCommitFilesChanged(commitHash);
 
       output.push({
         commitHash: commitHash,
         createdAt: commitInfo.committedDate,
         title: `${title} (${parseCommitMessage[0]})`,
+        files,
       });
+    }
+  }
+
+  // Check for files where collisions are likely
+  for (const {files} of output) {
+    for (const file of files) {
+      const count = allFiles.get(file) ?? 0;
+      allFiles.set(file, count + 1);
     }
   }
 
@@ -126,6 +160,8 @@ const sortedPicks = allPickItems.sort((a, b) => {
 
 for (const pick of sortedPicks) {
   console.log(formatResultLine(pick.commitHash, pick.createdAt, pick.title));
+  const collisions = Array.from(pick.files).filter(file => (allFiles.get(file) ?? 0) > 1);
+  console.log(formatFileCollisions(collisions));
 }
 
 console.log(`\nTotal picks (${allPickItems.length})`);

--- a/src/parsing.ts
+++ b/src/parsing.ts
@@ -44,7 +44,7 @@ export function findMergeComment(comments: any[]) {
   const botComment = comments.find(
     (comment) =>
       comment.author.login === "react-native-bot" &&
-      comment.body.includes("This pull request was successfully merged by")
+      comment.body.includes("This pull request was successfully merged by"),
   );
 
   if (botComment) {

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -96,17 +96,17 @@ export async function queryProjectInbox({
     const fieldValues = item.fieldValues.nodes;
     // filter fieldValues out if it is an empty object
     const filteredFieldValues = fieldValues.filter(
-      (field: any) => Object.keys(field).length > 0
+      (field: any) => Object.keys(field).length > 0,
     );
 
     const statusField = filteredFieldValues.find(
-      (field: any) => field?.field.name === "Status"
+      (field: any) => field?.field.name === "Status",
     );
     const targetReleaseField = filteredFieldValues.find(
-      (field: any) => field?.field.name === "Target Release"
+      (field: any) => field?.field.name === "Target Release",
     );
     const titleField = filteredFieldValues.find(
-      (field: any) => field?.field.name === "Title"
+      (field: any) => field?.field.name === "Title",
     );
 
     if (statusField !== undefined && targetReleaseField !== undefined) {
@@ -151,7 +151,7 @@ export async function queryPullRequest(num: number) {
   const data = JSON.parse(output).data;
 
   const mergeInfo = findMergeComment(
-    data.repository.pullRequest.comments.nodes
+    data.repository.pullRequest.comments.nodes,
   );
 
   return mergeInfo;
@@ -198,4 +198,3 @@ export function queryCommitFilesChanged(sha: string): Set<string> {
   ]);
   return new Set(proc.stdout.toString().trim().split("\n"));
 }
-

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -187,3 +187,15 @@ export async function queryCommitInfo(commitHash: string) {
 
   return data.repository.object;
 }
+
+export function queryCommitFilesChanged(sha: string): Set<string> {
+  const proc = Bun.spawnSync([
+    "gh",
+    "api",
+    "/repos/facebook/react-native/commits/" + sha,
+    "-q",
+    ".files[].filename",
+  ]);
+  return new Set(proc.stdout.toString().trim().split("\n"));
+}
+


### PR DESCRIPTION
## Change:
I've tried to identify files that come up across the picks, so we can focus on where collisions might occur.  I've also run `npx prettier -w src/*` to try make the formatting inline with yours.  It's difficult to demo at the moment, because I've had to move some pick requests temporarily.  It will look something like this when there are collisions:

![CleanShot 2024-09-25 at 13 48 33@2x](https://github.com/user-attachments/assets/27b5c5f0-331c-42a5-97b6-c1e001b128f4)

## Changes:
- **feat: show files that could collide across picks**
- **chore: npx prettier -w src/***
