### PR TITLE
feat: parse PRs added to project board

### DIFF
--- a/src/parsing.ts
+++ b/src/parsing.ts
@@ -1,7 +1,7 @@
 function getLinkToCommitOrPullRequestSection(issueBody: string): string {
   // Use a regular expression to find the "Link to commit or PR to be picked" section
   const linkSectionRegex = /### Link to commit or PR to be picked\s+([\s\S]*?)\s+###/i
-  const sectionMatch = issueBody.match(linkSectionRegex)
+  const sectionMatch = issueBody?.match(linkSectionRegex)
 
   if (!sectionMatch) {
     return ""
@@ -15,7 +15,7 @@ function getLinkToCommitOrPullRequestSection(issueBody: string): string {
 
 function getDescriptionSection(issueBody: string): string {
   const descriptionRegex = /### Description\s*([\s\S]*?)\s*(?=###|$)/i
-  const sectionMatch = issueBody.match(descriptionRegex)
+  const sectionMatch = issueBody?.match(descriptionRegex)
 
   if (!sectionMatch) {
     return ""
@@ -74,7 +74,7 @@ export function parseCommitLinks(issueBody: string): string[] {
     if (descriptionContent.length === 0) {
       // try to just match commit bullets in the entire body from
       // submissions not following the GH template (huntie xD)
-      const bodyMatches = issueBody.match(commitLinkRegex)
+      const bodyMatches = issueBody?.match(commitLinkRegex)
       return bodyMatches || []
     } else {
       // Find all matches of the pull request links

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -74,12 +74,24 @@ export async function queryProjectInbox({
                 }
               }
               content {
+                __typename
                 ... on Issue {
                   number
                   title
                   body
                   createdAt
                   url
+                }
+                ... on PullRequest {  
+                  number
+                  title
+                  body
+                  createdAt
+                  url
+                  mergedAt
+                  state
+                  baseRefName
+                  headRefName
                 }
               }
             }


### PR DESCRIPTION
## Description
- Had to parse not only issues coming back from the project board, but PRs themselves

## Example Output (RC4)
```bash
Target release 0.76.0-rc4
7c60a65 : 2024-09-27T20:11:45Z : [0.76][iOS] Fabric: Fixes animations strict weak ordering sorted check failed (Fabric: Fixes animations strict weak ordering sorted check failed (#46582))

aa35a21 : 2024-09-30T13:03:22Z : [0.76] Fix the generation of .xcode.env.local (Fix the generation of .xcode.env.local (#46661))

5c7a166 : 2024-09-30T15:04:36Z : [0.76] title and title color handling added for refresh control  (fix(iOS): title and title color handling added for refresh control (#46655))

6a09fc0 : 2024-10-02T04:38:20Z : [0.76] Rename `RCTUIGraphicsImageRenderer` to `RCTMakeUIGraphicsImageRenderer`
 - packages/react-native/React/Views/RCTBorderDrawing.m
47748c7 : 2024-10-02T21:06:44Z : [0.76] fix(iOS): Properly retain/release backgroundColor in RCTBorderDrawing
 - packages/react-native/React/Views/RCTBorderDrawing.m
7487a2c : 2024-10-03T14:12:43Z : [0.76] Allow apps to take control of bundling (Allow taking control of bundle loading on new arch (#46731))

eeb6122 : 2024-10-04T11:42:01Z : [0.76] Respond with `200` when opening debugger

cbb3132 : 2024-10-04T16:05:45Z : [0.76] Fix errors with component stacks reported as warnings


Total picks (8)

To discuss (3):
46790 : [0.76] Update debugger-frontend from e8c7943...ce5d32a
 - branch : 0.76-stable <- 0.76-devtools-frontend-launch-updates
 - https://github.com/facebook/react-native/pull/46790
46815 : [0.76][Fix] Restore Metro log forwarding, change notice to signal future removal
 - branch : 0.76-stable <- 0.76-restore-metro-logs
 - https://github.com/facebook/react-native/pull/46815
559 : [0.76] Update ReactNativeFlipper deprecation to ERROR
 - branch : 0.76-stable
 - https://github.com/reactwg/react-native-releases/issues/559
```